### PR TITLE
fix: Logout on token expiration

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -41,8 +41,7 @@ if (localStorage.jwtToken) {
   const currentTime = Date.now() / 1000;
   if (decoded.exp < currentTime) {
     // Logout user
-    store.dispatch(logoutUser);
-    //TODO:  Clear current Profile
+    store.dispatch(logoutUser());
     store.dispatch(clearCurrentProfile());
     // Redirect to login
     window.location.href = "/login";


### PR DESCRIPTION
fixes #1 

The users weren't being logged out on token expiration, because there was an error on `logoutUser` calling. Instead of doing this
```
store.dispatch(logoutUser());
```
the code was like this
```
store.dispatch(logoutUser);
```
